### PR TITLE
feat: add PM2 deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,51 @@ You can deploy `atprotoblog` using Docker for a more streamlined and isolated en
 
 This approach will help in quickly deploying the application, allowing you to manage it effectively with Docker's features like container restarts and isolated environments.
 
+## PM2 Deployment
+
+As an alternative to Docker deployment, you can use PM2 to run the application:
+
+### Prerequisites
+- Node.js 18 or later
+- Yarn package manager
+- PM2 (installed globally or as a project dependency)
+
+### Deployment Steps
+
+1. Install dependencies:
+```bash
+yarn install
+```
+
+2. Build the application:
+```bash
+yarn build
+```
+
+3. Start the application with PM2:
+```bash
+yarn start:pm2
+```
+
+### PM2 Management Commands
+
+- Stop the application: `yarn stop:pm2`
+- Reload the application: `yarn reload:pm2`
+- View logs: `pm2 logs atprotoblog`
+- Monitor: `pm2 monit`
+- List running apps: `pm2 list`
+
+### Environment Variables
+
+Make sure to set up your environment variables before deploying. You can modify them in the `ecosystem.config.js` file:
+
+- `NODE_ENV`: Production environment
+- `ATP_SERVICE`: Your ATP service URL
+- `ATP_IDENTIFIER`: Your ATP identifier
+- `ATP_DID`: Your ATP DID
+- `REDIS_URL`: Redis connection URL
+- `PORT`: Application port (default: 3000)
+
 ## Related Project
 
 This project is based on [blug](https://github.com/haileyok/blug) by haileyok. I have made some modifications and Dockerized it to make deployment easier.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  apps: [
+    {
+      name: 'atprotoblog',
+      script: 'build/index.js',
+      instances: 'max',
+      exec_mode: 'cluster',
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '1G',
+      env: {
+        NODE_ENV: 'production',
+        ATP_SERVICE: 'https://pds.skiddle.id',
+        ATP_IDENTIFIER: 'skiddle.id',
+        ATP_DID: 'did:plc:kbpcqituf5ku6xorxo2wzdee',
+        REDIS_URL: 'redis://localhost:6379',
+        PORT: 3000
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "remix build",
     "dev": "remix dev",
     "start": "remix-serve build/index.js",
+    "start:pm2": "pm2 start ecosystem.config.js",
+    "stop:pm2": "pm2 stop ecosystem.config.js",
+    "reload:pm2": "pm2 reload ecosystem.config.js",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "typecheck": "tsc"
   },
@@ -22,6 +25,7 @@
     "framer-motion": "^11.11.17",
     "ioredis": "^5.3.2",
     "isbot": "^4.1.0",
+    "pm2": "^5.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",


### PR DESCRIPTION
- Add ecosystem.config.js for PM2 setup
- Add PM2 scripts to package.json
- Add PM2 deployment documentation to README.md

## Summary by Sourcery

Add PM2 as a deployment option for the application.

Deployment:
- Introduce PM2 for application deployment.

Documentation:
- Document PM2 deployment steps and related commands in the README.